### PR TITLE
prevent adding of double extension

### DIFF
--- a/modules/core/src/com/haulmont/reports/ReportingBean.java
+++ b/modules/core/src/com/haulmont/reports/ReportingBean.java
@@ -523,7 +523,7 @@ public class ReportingBean implements ReportingApi {
     protected FileDescriptor saveReport(byte[] reportData, String fileName, String ext) {
         FileDescriptor file = metadata.create(FileDescriptor.class);
         file.setCreateDate(timeSource.currentTimestamp());
-        file.setName(fileName + "." + ext);
+        file.setName(createReportFileName(fileName, ext));
         file.setExtension(ext);
         file.setSize((long) reportData.length);
 
@@ -542,6 +542,13 @@ public class ReportingBean implements ReportingApi {
             tx.end();
         }
         return file;
+    }
+
+    protected String createReportFileName(String fileName, String ext) {
+        if (fileName != null && ext != null && !fileName.toLowerCase().endsWith("." + ext.toLowerCase())) {
+            return fileName + "." + ext;
+        }
+        return fileName;
     }
 
     @Override

--- a/modules/core/test/com/haulmont/reports/ReportingBeanTest.java
+++ b/modules/core/test/com/haulmont/reports/ReportingBeanTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2021 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.haulmont.reports;
+
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class ReportingBeanTest {
+
+    @Test
+    public void doubleExtension() {
+        ReportingBean reportingBean = new ReportingBean();
+        String basicName = "basicFileName.pdf";
+        String fileName = reportingBean.createReportFileName(basicName, "pdf");
+        Assert.assertEquals(basicName, fileName);
+    }
+}


### PR DESCRIPTION
Only add the file extension, if it is not already added. See Reporting.java line number 232 in yarg. The extension is already added there. 